### PR TITLE
Create Pixi + GSAP triangle forest demo

### DIFF
--- a/src/lib/simple-gsap.ts
+++ b/src/lib/simple-gsap.ts
@@ -1,0 +1,214 @@
+export type EaseFunction = (t: number) => number
+
+export interface TweenVars {
+  duration?: number
+  delay?: number
+  repeat?: number
+  yoyo?: boolean
+  ease?: EaseFunction | string
+  onUpdate?: () => void
+  onComplete?: () => void
+  onRepeat?: () => void
+  [key: string]: unknown
+}
+
+interface TweenState {
+  property: string
+  start: number
+  end: number
+  initialStart: number
+  initialEnd: number
+}
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value))
+
+const EASES: Record<string, EaseFunction> = {
+  linear: (t) => t,
+  'sine.inOut': (t) => -(Math.cos(Math.PI * t) - 1) / 2,
+  'power2.out': (t) => 1 - Math.pow(1 - t, 2),
+  'power2.inOut': (t) => (t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2)
+}
+
+const resolveEase = (ease?: EaseFunction | string): EaseFunction => {
+  if (!ease) return EASES.linear
+  if (typeof ease === 'function') return ease
+  return EASES[ease] ?? EASES.linear
+}
+
+class Tween {
+  private startTime = 0
+  private delay = 0
+  private duration = 0
+  private states: TweenState[] = []
+  private ease: EaseFunction
+  private rafId: number | null = null
+  private repeat = 0
+  private repeatCounter = 0
+  private yoyo = false
+  private reversed = false
+  private target: Record<string, number>
+  private vars: TweenVars
+
+  constructor(target: unknown, vars: TweenVars) {
+    this.target = target as Record<string, number>
+    this.vars = vars
+    const { duration = 1, delay = 0, ease, repeat = 0, yoyo = false } = vars
+    this.duration = Math.max(0.0001, duration)
+    this.delay = Math.max(0, delay)
+    this.ease = resolveEase(ease)
+    this.repeat = repeat
+    this.repeatCounter = repeat
+    this.yoyo = yoyo
+
+    this.states = Object.entries(vars)
+      .filter(([key]) => !['duration', 'delay', 'ease', 'repeat', 'yoyo', 'onUpdate', 'onComplete', 'onRepeat'].includes(key))
+      .map(([property, endValue]) => {
+        const startValue = Number(this.target[property])
+        return {
+          property,
+          start: startValue,
+          end: Number(endValue),
+          initialStart: startValue,
+          initialEnd: Number(endValue)
+        }
+      })
+  }
+
+  play() {
+    this.startTime = performance.now()
+    const tick = () => {
+      const now = performance.now()
+      const elapsed = now - this.startTime
+      if (elapsed < this.delay * 1000) {
+        this.rafId = requestAnimationFrame(tick)
+        return
+      }
+
+      const progress = clamp((elapsed - this.delay * 1000) / (this.duration * 1000), 0, 1)
+      const eased = this.ease(this.reversed ? 1 - progress : progress)
+
+      for (const state of this.states) {
+        const value = state.start + (state.end - state.start) * eased
+        ;(this.target as Record<string, number>)[state.property] = value
+      }
+
+      this.vars.onUpdate?.()
+
+      if (progress >= 1) {
+        if (this.repeat === -1 || this.repeatCounter > 0) {
+          if (this.repeatCounter > 0) {
+            this.repeatCounter -= 1
+          }
+          if (this.yoyo) {
+            this.reversed = !this.reversed
+          } else {
+            for (const state of this.states) {
+              state.start = state.initialStart
+              state.end = state.initialEnd
+              ;(this.target as Record<string, number>)[state.property] = state.initialStart
+            }
+          }
+          this.startTime = performance.now()
+          this.vars.onRepeat?.()
+          this.rafId = requestAnimationFrame(tick)
+          return
+        }
+
+        this.vars.onComplete?.()
+        return
+      }
+
+      this.rafId = requestAnimationFrame(tick)
+    }
+
+    this.rafId = requestAnimationFrame(tick)
+    return this
+  }
+
+  kill() {
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId)
+    }
+  }
+}
+
+class Timeline {
+  private tweens: { tween: Tween; offset: number }[] = []
+  private startTime = 0
+  private duration = 0
+  private rafId: number | null = null
+  private repeat = 0
+  private repeatCounter = 0
+
+  constructor(options: { repeat?: number } = {}) {
+    this.repeat = options.repeat ?? 0
+    this.repeatCounter = this.repeat
+  }
+
+  to(target: unknown, vars: TweenVars, position?: number) {
+    const tween = new Tween(target, vars)
+    const offset = (position ?? this.duration) * 1000
+    const endTime = offset + (vars.duration ?? 1) * 1000 + (vars.delay ?? 0) * 1000
+    this.duration = Math.max(this.duration, endTime / 1000)
+    this.tweens.push({ tween, offset })
+    return this
+  }
+
+  play() {
+    this.startTime = performance.now()
+    const tick = () => {
+      const now = performance.now()
+      const elapsed = now - this.startTime
+
+      for (const entry of this.tweens) {
+        if (elapsed >= entry.offset && !(entry as { started?: boolean }).started) {
+          ;(entry as { started?: boolean }).started = true
+          entry.tween.play()
+        }
+      }
+
+      if (elapsed >= this.duration * 1000) {
+        if (this.repeat === -1 || this.repeatCounter > 0) {
+          if (this.repeatCounter > 0) {
+            this.repeatCounter -= 1
+          }
+          for (const entry of this.tweens) {
+            entry.tween.kill()
+            ;(entry as { started?: boolean }).started = false
+          }
+          this.startTime = performance.now()
+          this.rafId = requestAnimationFrame(tick)
+          return
+        }
+        return
+      }
+
+      this.rafId = requestAnimationFrame(tick)
+    }
+
+    this.rafId = requestAnimationFrame(tick)
+    return this
+  }
+
+  kill() {
+    if (this.rafId) {
+      cancelAnimationFrame(this.rafId)
+      this.rafId = null
+    }
+    for (const entry of this.tweens) {
+      entry.tween.kill()
+    }
+  }
+}
+
+export const gsap = {
+  to(target: unknown, vars: TweenVars) {
+    return new Tween(target, vars).play()
+  },
+  timeline(options?: { repeat?: number }) {
+    return new Timeline(options)
+  }
+}
+
+export type TweenInstance = ReturnType<typeof gsap.to>
+export type TimelineInstance = ReturnType<typeof gsap.timeline>

--- a/src/lib/simple-pixi.ts
+++ b/src/lib/simple-pixi.ts
@@ -1,0 +1,220 @@
+export interface ApplicationInitOptions {
+  background?: string
+  width?: number
+  height?: number
+  resizeTo?: Window | HTMLElement
+}
+
+const DEFAULT_BACKGROUND = '#0f172a'
+
+const colorToStyle = (color: number | string, alpha = 1): string => {
+  if (typeof color === 'string') {
+    return color
+  }
+
+  const hex = color.toString(16).padStart(6, '0')
+  if (alpha >= 1) {
+    return `#${hex}`
+  }
+
+  const r = parseInt(hex.slice(0, 2), 16)
+  const g = parseInt(hex.slice(2, 4), 16)
+  const b = parseInt(hex.slice(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+abstract class DisplayObject {
+  [key: string]: unknown
+  x = 0
+  y = 0
+  rotation = 0
+  alpha = 1
+  scale = { x: 1, y: 1 }
+  parent: Container | null = null
+
+  protected abstract drawSelf(ctx: CanvasRenderingContext2D): void
+
+  render(ctx: CanvasRenderingContext2D) {
+    ctx.save()
+    ctx.translate(this.x, this.y)
+    ctx.rotate(this.rotation)
+    ctx.scale(this.scale.x, this.scale.y)
+    const previousAlpha = ctx.globalAlpha
+    ctx.globalAlpha = previousAlpha * this.alpha
+    this.drawSelf(ctx)
+    ctx.globalAlpha = previousAlpha
+    ctx.restore()
+  }
+}
+
+export class Container extends DisplayObject {
+  children: DisplayObject[] = []
+
+  addChild<T extends DisplayObject>(child: T): T {
+    child.parent = this
+    this.children.push(child)
+    return child
+  }
+
+  removeChild<T extends DisplayObject>(child: T): T {
+    const index = this.children.indexOf(child)
+    if (index >= 0) {
+      this.children.splice(index, 1)
+      child.parent = null
+    }
+    return child
+  }
+
+  protected drawSelf(ctx: CanvasRenderingContext2D) {
+    for (const child of this.children) {
+      child.render(ctx)
+    }
+  }
+}
+
+type Shape =
+  | {
+      type: 'circle'
+      radius: number
+      offsetX: number
+      offsetY: number
+      fill: string
+    }
+  | {
+      type: 'polygon'
+      points: number[]
+      fill: string
+    }
+
+export class Graphics extends Container {
+  private shapes: Shape[] = []
+  private currentFill: { color: string; alpha: number } | null = null
+
+  clear() {
+    this.shapes = []
+  }
+
+  beginFill(color: number | string, alpha = 1) {
+    this.currentFill = { color: colorToStyle(color, alpha), alpha }
+  }
+
+  endFill() {
+    this.currentFill = null
+  }
+
+  drawCircle(x: number, y: number, radius: number) {
+    if (!this.currentFill) return
+    this.shapes.push({
+      type: 'circle',
+      radius,
+      offsetX: x,
+      offsetY: y,
+      fill: this.currentFill.color
+    })
+  }
+
+  drawPolygon(points: number[]) {
+    if (!this.currentFill) return
+    this.shapes.push({ type: 'polygon', points: [...points], fill: this.currentFill.color })
+  }
+
+  protected drawSelf(ctx: CanvasRenderingContext2D) {
+    for (const shape of this.shapes) {
+      ctx.save()
+      ctx.fillStyle = shape.fill
+      if (shape.type === 'circle') {
+        ctx.beginPath()
+        ctx.arc(shape.offsetX, shape.offsetY, shape.radius, 0, Math.PI * 2)
+        ctx.closePath()
+        ctx.fill()
+      } else if (shape.type === 'polygon') {
+        const [startX, startY, ...rest] = shape.points
+        ctx.beginPath()
+        ctx.moveTo(startX, startY)
+        for (let i = 0; i < rest.length; i += 2) {
+          ctx.lineTo(rest[i], rest[i + 1])
+        }
+        ctx.closePath()
+        ctx.fill()
+      }
+      ctx.restore()
+    }
+
+    super.drawSelf(ctx)
+  }
+}
+
+export class Application {
+  readonly stage = new Container()
+  readonly canvas: HTMLCanvasElement
+  private ctx: CanvasRenderingContext2D
+  private background: string = DEFAULT_BACKGROUND
+  private animationFrame: number | null = null
+
+  constructor() {
+    this.canvas = document.createElement('canvas')
+    const context = this.canvas.getContext('2d')
+    if (!context) {
+      throw new Error('Unable to acquire 2D rendering context')
+    }
+    this.ctx = context
+  }
+
+  async init(options: ApplicationInitOptions = {}) {
+    const { background = DEFAULT_BACKGROUND, width = 800, height = 600, resizeTo } = options
+    this.background = background
+
+    if (resizeTo instanceof Window) {
+      this.resizeWithWindow(resizeTo)
+    } else if (resizeTo) {
+      this.resizeToElement(resizeTo)
+    } else {
+      this.canvas.width = width
+      this.canvas.height = height
+    }
+
+    this.start()
+  }
+
+  private resizeWithWindow(target: Window) {
+    const updateSize = () => {
+      this.canvas.width = target.innerWidth
+      this.canvas.height = target.innerHeight
+    }
+    target.addEventListener('resize', updateSize)
+    updateSize()
+  }
+
+  private resizeToElement(element: HTMLElement) {
+    const updateSize = () => {
+      this.canvas.width = element.clientWidth
+      this.canvas.height = element.clientHeight
+    }
+    window.addEventListener('resize', updateSize)
+    updateSize()
+  }
+
+  private start() {
+    const loop = () => {
+      this.animationFrame = requestAnimationFrame(loop)
+      this.render()
+    }
+    loop()
+  }
+
+  private render() {
+    this.ctx.save()
+    this.ctx.fillStyle = this.background
+    this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height)
+    this.ctx.restore()
+
+    this.stage.render(this.ctx)
+  }
+
+  destroy() {
+    if (this.animationFrame) {
+      cancelAnimationFrame(this.animationFrame)
+      this.animationFrame = null
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,24 +1,127 @@
 import './style.css'
-import typescriptLogo from './typescript.svg'
-import viteLogo from '/vite.svg'
-import { setupCounter } from './counter.ts'
+import { Application, Container, Graphics } from './lib/simple-pixi'
+import { gsap } from './lib/simple-gsap'
 
-document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://www.typescriptlang.org/" target="_blank">
-      <img src="${typescriptLogo}" class="logo vanilla" alt="TypeScript logo" />
-    </a>
-    <h1>Vite + TypeScript</h1>
-    <div class="card">
-      <button id="counter" type="button"></button>
-    </div>
-    <p class="read-the-docs">
-      Click on the Vite and TypeScript logos to learn more
-    </p>
-  </div>
+const randomRange = (min: number, max: number) => Math.random() * (max - min) + min
+
+const app = new Application()
+
+const mount = document.querySelector<HTMLDivElement>('#app')
+if (!mount) {
+  throw new Error('Root container "#app" was not found')
+}
+
+await app.init({ background: '#020617', resizeTo: window })
+mount.appendChild(app.canvas)
+
+const forest = new Container()
+app.stage.addChild(forest)
+
+const circle = new Graphics()
+circle.beginFill(0x38bdf8)
+circle.drawCircle(0, 0, 24)
+circle.endFill()
+app.stage.addChild(circle)
+
+let circleTween: ReturnType<typeof gsap.to> | null = null
+const treeTweens: Array<ReturnType<typeof gsap.to>> = []
+let forestDepth = 0
+
+const clearContainer = (container: Container) => {
+  while (container.children.length) {
+    container.removeChild(container.children[0])
+  }
+}
+
+const buildForest = () => {
+  treeTweens.splice(0).forEach((tween) => tween.kill?.())
+  clearContainer(forest)
+
+  const width = app.canvas.width
+  const height = app.canvas.height
+  const layers = 3
+  const treesPerLayer = 28
+  const palette = ['#0f172a', '#1e293b', '#334155']
+  forestDepth = height * 2.5
+
+  for (let layer = 0; layer < layers; layer += 1) {
+    const depthFactor = 1 - layer / layers
+    const layerAlpha = 0.25 + depthFactor * 0.45
+    const baseSize = 60 + layer * 25
+    const spacing = forestDepth / treesPerLayer
+
+    for (let i = 0; i < treesPerLayer; i += 1) {
+      const tree = new Graphics()
+      const size = randomRange(baseSize * 0.6, baseSize * 1.3)
+      tree.beginFill(palette[layer % palette.length])
+      tree.drawPolygon([
+        -size / 2,
+        0,
+        0,
+        -size,
+        size / 2,
+        0
+      ])
+      tree.endFill()
+      tree.alpha = layerAlpha
+      tree.x = randomRange(-size, width + size)
+      const jitter = randomRange(-spacing * 0.3, spacing * 0.3)
+      tree.y = height - i * spacing - layer * (spacing / 3) + jitter
+      forest.addChild(tree)
+
+      const floatDistance = randomRange(6, 18) * depthFactor
+      const duration = randomRange(3.2, 6.4) + layer
+      const tween = gsap.to(tree, {
+        y: tree.y - floatDistance,
+        duration,
+        ease: 'sine.inOut',
+        repeat: -1,
+        yoyo: true,
+        delay: randomRange(0, 2.5)
+      })
+      treeTweens.push(tween)
+    }
+  }
+}
+
+const animateCircle = () => {
+  circleTween?.kill?.()
+  const width = app.canvas.width
+  const height = app.canvas.height
+
+  circle.x = width / 2
+  circle.y = height + 60
+
+  circleTween = gsap.to(circle, {
+    y: -forestDepth,
+    duration: 12,
+    ease: 'power2.inOut',
+    repeat: -1,
+    onRepeat: () => {
+      circle.x = width / 2 + randomRange(-width * 0.15, width * 0.15)
+    }
+  })
+}
+
+const rebuildScene = () => {
+  buildForest()
+  animateCircle()
+}
+
+rebuildScene()
+
+let resizeTimeout: number | undefined
+window.addEventListener('resize', () => {
+  window.clearTimeout(resizeTimeout)
+  resizeTimeout = window.setTimeout(() => {
+    rebuildScene()
+  }, 150)
+})
+
+const label = document.createElement('div')
+label.className = 'scene-label'
+label.innerHTML = `
+  <strong>PixiJS</strong> + <strong>GSAP</strong><br />
+  Circle gliding through a triangle forest
 `
-
-setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
+mount.appendChild(label)

--- a/src/style.css
+++ b/src/style.css
@@ -1,96 +1,55 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  color-scheme: dark;
+  font-family: 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #020617;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  background: radial-gradient(circle at 20% 20%, #1e293b, #020617 65%);
+  color: #e2e8f0;
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  filter: drop-shadow(0 0 20px rgba(56, 189, 248, 0.15));
+}
+
+.scene-label {
+  position: absolute;
+  left: 50%;
+  bottom: 32px;
+  transform: translateX(-50%);
   text-align: center;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.85);
+  padding: 0.5rem 1.5rem;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 999px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 12px 45px rgba(15, 23, 42, 0.6);
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.vanilla:hover {
-  filter: drop-shadow(0 0 2em #3178c6aa);
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.scene-label strong {
+  color: #38bdf8;
 }


### PR DESCRIPTION
## Summary
- add lightweight PixiJS-style canvas renderer and GSAP-inspired tweening helper for offline builds
- replace the starter app with a Pixi scene that scatters layered triangle "trees" and animates a circle rising through them
- refresh styles with a full-screen dark backdrop and floating label for the demo

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccf75fb474832e86bbf38ff05fda54