### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+        env:
+          GITHUB_PAGES: "true"
+
+      - name: Upload production-ready files
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    permissions:
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+
+export default defineConfig(() => {
+  const repoName = process.env.GITHUB_REPOSITORY?.split("/")[1];
+  const isGitHubPages = process.env.GITHUB_PAGES === "true" && repoName;
+
+  return {
+    base: isGitHubPages ? `/${repoName}/` : "/",
+  };
+});


### PR DESCRIPTION
## Summary
- configure Vite to set the correct base path when building for GitHub Pages
- add a GitHub Actions workflow that builds the project and publishes the dist folder to Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccfa29377c832eb645e7f7fcbcc7cc