### PR TITLE
Add endless northbound battle scroller

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,25 @@
 import './style.css'
 import { Application, Container, Graphics } from './lib/simple-pixi'
-import { gsap } from './lib/simple-gsap'
+
+type Phase = 'travel' | 'battle' | 'enemy-turn' | 'gameover'
+
+interface Enemy {
+  level: number
+  title: string
+  maxHealth: number
+  health: number
+  attack: number
+}
 
 const randomRange = (min: number, max: number) => Math.random() * (max - min) + min
+
+const enemyTitles = ['Scout', 'Marauder', 'Sentinel', 'Phantom', 'Warden']
+const enemyLabel = (enemy: Enemy) => `Level ${enemy.level} ${enemy.title}`
+
+const TRAVEL_SPEED = 170
+const SEGMENT_COUNT = 6
+const SEGMENT_HEIGHT = 220
+const SEGMENT_SPACING = 180
 
 const app = new Application()
 
@@ -14,114 +31,536 @@ if (!mount) {
 await app.init({ background: '#020617', resizeTo: window })
 mount.appendChild(app.canvas)
 
-const forest = new Container()
-app.stage.addChild(forest)
+const world = new Container()
+app.stage.addChild(world)
 
-const circle = new Graphics()
-circle.beginFill(0x38bdf8)
-circle.drawCircle(0, 0, 24)
-circle.endFill()
-app.stage.addChild(circle)
+const pathContainer = new Container()
+world.addChild(pathContainer)
 
-let circleTween: ReturnType<typeof gsap.to> | null = null
-const treeTweens: Array<ReturnType<typeof gsap.to>> = []
-let forestDepth = 0
+const segments: Graphics[] = Array.from({ length: SEGMENT_COUNT }, () => {
+  const segment = new Graphics()
+  pathContainer.addChild(segment)
+  return segment
+})
 
-const clearContainer = (container: Container) => {
-  while (container.children.length) {
-    container.removeChild(container.children[0])
-  }
-}
+const playerGraphic = new Graphics()
+world.addChild(playerGraphic)
 
-const buildForest = () => {
-  treeTweens.splice(0).forEach((tween) => tween.kill?.())
-  clearContainer(forest)
+const enemyGraphic = new Graphics()
+enemyGraphic.visible = false
+world.addChild(enemyGraphic)
 
-  const width = app.canvas.width
-  const height = app.canvas.height
-  const layers = 3
-  const treesPerLayer = 28
-  const palette = ['#0f172a', '#1e293b', '#334155']
-  forestDepth = height * 2.5
+let currentEnemyLevelForScene = 1
 
-  for (let layer = 0; layer < layers; layer += 1) {
-    const depthFactor = 1 - layer / layers
-    const layerAlpha = 0.25 + depthFactor * 0.45
-    const baseSize = 60 + layer * 25
-    const spacing = forestDepth / treesPerLayer
-
-    for (let i = 0; i < treesPerLayer; i += 1) {
-      const tree = new Graphics()
-      const size = randomRange(baseSize * 0.6, baseSize * 1.3)
-      tree.beginFill(palette[layer % palette.length])
-      tree.drawPolygon([
-        -size / 2,
-        0,
-        0,
-        -size,
-        size / 2,
-        0
-      ])
-      tree.endFill()
-      tree.alpha = layerAlpha
-      tree.x = randomRange(-size, width + size)
-      const jitter = randomRange(-spacing * 0.3, spacing * 0.3)
-      tree.y = height - i * spacing - layer * (spacing / 3) + jitter
-      forest.addChild(tree)
-
-      const floatDistance = randomRange(6, 18) * depthFactor
-      const duration = randomRange(3.2, 6.4) + layer
-      const tween = gsap.to(tree, {
-        y: tree.y - floatDistance,
-        duration,
-        ease: 'sine.inOut',
-        repeat: -1,
-        yoyo: true,
-        delay: randomRange(0, 2.5)
-      })
-      treeTweens.push(tween)
-    }
-  }
-}
-
-const animateCircle = () => {
-  circleTween?.kill?.()
-  const width = app.canvas.width
-  const height = app.canvas.height
-
-  circle.x = width / 2
-  circle.y = height + 60
-
-  circleTween = gsap.to(circle, {
-    y: -forestDepth,
-    duration: 12,
-    ease: 'power2.inOut',
-    repeat: -1,
-    onRepeat: () => {
-      circle.x = width / 2 + randomRange(-width * 0.15, width * 0.15)
-    }
+const resetSegments = () => {
+  const start = -SEGMENT_SPACING * 2
+  segments.forEach((segment, index) => {
+    segment.y = start + index * SEGMENT_SPACING
   })
 }
 
-const rebuildScene = () => {
-  buildForest()
-  animateCircle()
+const drawPathSegment = (segment: Graphics, baseWidth: number) => {
+  const topWidth = baseWidth * 0.55
+  const bottomWidth = baseWidth
+  const centerLineBottom = bottomWidth * 0.14
+  const centerLineTop = topWidth * 0.14
+
+  segment.clear()
+  segment.beginFill(0x111827)
+  segment.drawPolygon([
+    -bottomWidth / 2,
+    SEGMENT_HEIGHT / 2,
+    bottomWidth / 2,
+    SEGMENT_HEIGHT / 2,
+    topWidth / 2,
+    -SEGMENT_HEIGHT / 2,
+    -topWidth / 2,
+    -SEGMENT_HEIGHT / 2
+  ])
+  segment.endFill()
+
+  segment.beginFill(0x1f2937)
+  segment.drawPolygon([
+    -bottomWidth / 2,
+    SEGMENT_HEIGHT / 2,
+    -bottomWidth * 0.7,
+    SEGMENT_HEIGHT / 2,
+    -topWidth * 0.65,
+    -SEGMENT_HEIGHT / 2,
+    -topWidth / 2,
+    -SEGMENT_HEIGHT / 2
+  ])
+  segment.endFill()
+
+  segment.beginFill(0x1f2937)
+  segment.drawPolygon([
+    bottomWidth / 2,
+    SEGMENT_HEIGHT / 2,
+    bottomWidth * 0.7,
+    SEGMENT_HEIGHT / 2,
+    topWidth * 0.65,
+    -SEGMENT_HEIGHT / 2,
+    topWidth / 2,
+    -SEGMENT_HEIGHT / 2
+  ])
+  segment.endFill()
+
+  segment.beginFill(0x93c5fd, 0.32)
+  segment.drawPolygon([
+    -centerLineBottom / 2,
+    SEGMENT_HEIGHT / 2,
+    centerLineBottom / 2,
+    SEGMENT_HEIGHT / 2,
+    centerLineTop / 2,
+    -SEGMENT_HEIGHT / 2,
+    -centerLineTop / 2,
+    -SEGMENT_HEIGHT / 2
+  ])
+  segment.endFill()
 }
 
-rebuildScene()
+const drawPlayer = (baseSize: number) => {
+  const height = Math.max(60, baseSize * 0.9)
+  const shoulderWidth = height * 0.55
+  const torsoHeight = height * 0.85
+
+  playerGraphic.clear()
+  playerGraphic.beginFill(0x0ea5e9)
+  playerGraphic.drawPolygon([
+    0,
+    -torsoHeight,
+    shoulderWidth * 0.45,
+    -torsoHeight * 0.25,
+    shoulderWidth * 0.32,
+    torsoHeight * 0.45,
+    -shoulderWidth * 0.32,
+    torsoHeight * 0.45,
+    -shoulderWidth * 0.45,
+    -torsoHeight * 0.25
+  ])
+  playerGraphic.endFill()
+
+  playerGraphic.beginFill(0x38bdf8)
+  playerGraphic.drawPolygon([
+    0,
+    -torsoHeight * 1.05,
+    height * 0.14,
+    -torsoHeight * 0.45,
+    0,
+    -torsoHeight * 0.35,
+    -height * 0.14,
+    -torsoHeight * 0.45
+  ])
+  playerGraphic.endFill()
+
+  playerGraphic.beginFill(0xf8fafc)
+  playerGraphic.drawCircle(0, -torsoHeight * 0.95, height * 0.18)
+  playerGraphic.endFill()
+
+  playerGraphic.beginFill(0x22d3ee)
+  playerGraphic.drawPolygon([
+    height * 0.2,
+    torsoHeight * 0.2,
+    height * 0.4,
+    -torsoHeight * 0.15,
+    height * 0.24,
+    -torsoHeight * 0.2,
+    height * 0.1,
+    torsoHeight * 0.1
+  ])
+  playerGraphic.endFill()
+}
+
+const drawEnemy = (level: number, baseSize: number) => {
+  const height = Math.max(70, baseSize * (0.9 + level * 0.08))
+  const shoulderWidth = height * 0.6
+
+  enemyGraphic.clear()
+  enemyGraphic.beginFill(0x991b1b)
+  enemyGraphic.drawPolygon([
+    0,
+    -height,
+    shoulderWidth * 0.55,
+    -height * 0.25,
+    shoulderWidth * 0.35,
+    height * 0.9,
+    0,
+    height * 0.55,
+    -shoulderWidth * 0.35,
+    height * 0.9,
+    -shoulderWidth * 0.55,
+    -height * 0.25
+  ])
+  enemyGraphic.endFill()
+
+  enemyGraphic.beginFill(0xef4444)
+  enemyGraphic.drawPolygon([
+    0,
+    -height * 0.85,
+    shoulderWidth * 0.38,
+    -height * 0.15,
+    0,
+    -height * 0.05,
+    -shoulderWidth * 0.38,
+    -height * 0.15
+  ])
+  enemyGraphic.endFill()
+
+  enemyGraphic.beginFill(0xfca5a5)
+  enemyGraphic.drawCircle(0, -height * 0.65, height * 0.24)
+  enemyGraphic.endFill()
+
+  enemyGraphic.beginFill(0xfee2e2)
+  enemyGraphic.drawCircle(-height * 0.09, -height * 0.65, height * 0.07)
+  enemyGraphic.drawCircle(height * 0.09, -height * 0.65, height * 0.07)
+  enemyGraphic.endFill()
+
+  enemyGraphic.beginFill(0x7f1d1d)
+  enemyGraphic.drawPolygon([
+    -shoulderWidth * 0.45,
+    -height * 0.4,
+    -shoulderWidth * 0.2,
+    -height * 0.7,
+    0,
+    -height * 0.55,
+    shoulderWidth * 0.2,
+    -height * 0.7,
+    shoulderWidth * 0.45,
+    -height * 0.4,
+    0,
+    -height * 0.3
+  ])
+  enemyGraphic.endFill()
+}
+
+let playerBaseY = 0
+let enemyBaseY = 0
+
+const layoutScene = () => {
+  const baseWidth = Math.min(app.canvas.width * 0.45, 360)
+  pathContainer.x = app.canvas.width / 2
+
+  segments.forEach((segment) => {
+    const previousY = segment.y
+    drawPathSegment(segment, baseWidth)
+    segment.y = previousY
+  })
+
+  const baseSize = Math.min(app.canvas.width, app.canvas.height)
+  playerBaseY = app.canvas.height * 0.75
+  enemyBaseY = app.canvas.height * 0.32
+
+  playerGraphic.x = app.canvas.width / 2
+  playerGraphic.y = playerBaseY
+  drawPlayer(baseSize * 0.08)
+
+  enemyGraphic.x = app.canvas.width / 2
+  enemyGraphic.y = enemyBaseY
+  drawEnemy(currentEnemyLevelForScene, baseSize * 0.08)
+}
+
+resetSegments()
+layoutScene()
 
 let resizeTimeout: number | undefined
 window.addEventListener('resize', () => {
   window.clearTimeout(resizeTimeout)
   resizeTimeout = window.setTimeout(() => {
-    rebuildScene()
-  }, 150)
+    layoutScene()
+  }, 120)
 })
 
-const label = document.createElement('div')
-label.className = 'scene-label'
-label.innerHTML = `
-  <strong>PixiJS</strong> + <strong>GSAP</strong><br />
-  Circle gliding through a triangle forest
+const hud = document.createElement('div')
+hud.className = 'hud'
+hud.innerHTML = `
+  <div class="hud-card">
+    <div class="hud-title">Traveler</div>
+    <div class="hud-metric"><span class="hud-label">Health</span><span class="hud-value" data-id="player-health">100</span></div>
+    <div class="hud-metric"><span class="hud-label">Attack</span><span class="hud-value">10</span></div>
+    <div class="hud-metric"><span class="hud-label">Kills</span><span class="hud-value" data-id="player-kills">0</span></div>
+  </div>
+  <div class="hud-card">
+    <div class="hud-title">Encounter</div>
+    <div class="hud-metric"><span class="hud-label">Enemy</span><span class="hud-value" data-id="enemy-name">—</span></div>
+    <div class="hud-metric"><span class="hud-label">Health</span><span class="hud-value" data-id="enemy-health">—</span></div>
+    <div class="hud-metric"><span class="hud-label">Attack</span><span class="hud-value" data-id="enemy-attack">—</span></div>
+  </div>
 `
-mount.appendChild(label)
+mount.appendChild(hud)
+
+const playerHealthEl = hud.querySelector('[data-id="player-health"]') as HTMLSpanElement
+const playerKillsEl = hud.querySelector('[data-id="player-kills"]') as HTMLSpanElement
+const enemyNameEl = hud.querySelector('[data-id="enemy-name"]') as HTMLSpanElement
+const enemyHealthEl = hud.querySelector('[data-id="enemy-health"]') as HTMLSpanElement
+const enemyAttackEl = hud.querySelector('[data-id="enemy-attack"]') as HTMLSpanElement
+
+const travelProgress = document.createElement('div')
+travelProgress.className = 'travel-progress'
+travelProgress.innerHTML = `
+  <div class="travel-progress__label">Northbound distance</div>
+  <div class="travel-progress__track"><div class="travel-progress__fill" data-id="progress-fill"></div></div>
+`
+mount.appendChild(travelProgress)
+
+const progressFillEl = travelProgress.querySelector('[data-id="progress-fill"]') as HTMLDivElement
+
+const statusEl = document.createElement('div')
+statusEl.className = 'status'
+mount.appendChild(statusEl)
+
+const controls = document.createElement('div')
+controls.className = 'controls'
+
+const attackButton = document.createElement('button')
+attackButton.className = 'attack-button'
+attackButton.type = 'button'
+attackButton.textContent = 'Attack'
+attackButton.disabled = true
+
+controls.appendChild(attackButton)
+mount.appendChild(controls)
+
+const endScreen = document.createElement('div')
+endScreen.className = 'end-screen'
+endScreen.innerHTML = `
+  <div class="end-screen__card">
+    <h2>Journey Ends</h2>
+    <p>You defeated <strong><span data-id="final-kills">0</span></strong> enemies.</p>
+    <button type="button" class="restart-button">Restart</button>
+  </div>
+`
+mount.appendChild(endScreen)
+
+const finalKillsEl = endScreen.querySelector('[data-id="final-kills"]') as HTMLSpanElement
+const restartButton = endScreen.querySelector('.restart-button') as HTMLButtonElement
+
+const setStatus = (message: string) => {
+  statusEl.textContent = message
+}
+
+const timeouts: number[] = []
+const scheduleTimeout = (callback: () => void, delay: number) => {
+  const id = window.setTimeout(() => {
+    const index = timeouts.indexOf(id)
+    if (index >= 0) {
+      timeouts.splice(index, 1)
+    }
+    callback()
+  }, delay)
+  timeouts.push(id)
+  return id
+}
+
+const clearScheduled = () => {
+  while (timeouts.length) {
+    const id = timeouts.pop()
+    if (id !== undefined) {
+      window.clearTimeout(id)
+    }
+  }
+}
+
+const randomTravelTarget = () => randomRange(700, 1300)
+
+const game = {
+  phase: 'travel' as Phase,
+  playerHealth: 100,
+  playerDamage: 10,
+  kills: 0,
+  travelProgress: 0,
+  travelTarget: randomTravelTarget(),
+  currentEnemy: null as Enemy | null
+}
+
+const updateHud = () => {
+  playerHealthEl.textContent = Math.max(0, Math.floor(game.playerHealth)).toString()
+  playerKillsEl.textContent = game.kills.toString()
+
+  if (game.currentEnemy) {
+    enemyNameEl.textContent = enemyLabel(game.currentEnemy)
+    enemyHealthEl.textContent = `${Math.max(0, Math.floor(game.currentEnemy.health))}/${game.currentEnemy.maxHealth}`
+    enemyAttackEl.textContent = game.currentEnemy.attack.toString()
+  } else {
+    enemyNameEl.textContent = '—'
+    enemyHealthEl.textContent = '—'
+    enemyAttackEl.textContent = '—'
+  }
+}
+
+const updateProgressBar = () => {
+  const ratio = game.phase === 'travel' ? Math.min(game.travelProgress / game.travelTarget, 1) : 0
+  progressFillEl.style.width = `${Math.floor(ratio * 100)}%`
+}
+
+const hideEndScreen = () => {
+  endScreen.classList.remove('end-screen--visible')
+}
+
+const showEndScreen = () => {
+  finalKillsEl.textContent = game.kills.toString()
+  endScreen.classList.add('end-screen--visible')
+}
+
+const beginTravel = () => {
+  clearScheduled()
+  game.phase = 'travel'
+  game.travelProgress = 0
+  game.travelTarget = randomTravelTarget()
+  game.currentEnemy = null
+  enemyGraphic.visible = false
+  currentEnemyLevelForScene = 1
+  attackButton.disabled = true
+  setStatus('Traveling north...')
+  updateHud()
+  updateProgressBar()
+}
+
+const beginEncounter = () => {
+  if (game.phase !== 'travel') return
+
+  clearScheduled()
+  const level = game.kills + 1
+  const title = enemyTitles[(level - 1) % enemyTitles.length]
+  const maxHealth = level * 10
+  const attack = level
+  const enemy: Enemy = {
+    level,
+    title,
+    maxHealth,
+    health: maxHealth,
+    attack
+  }
+  game.currentEnemy = enemy
+  game.phase = 'battle'
+  attackButton.disabled = false
+  enemyGraphic.visible = true
+  currentEnemyLevelForScene = enemy.level
+
+  const baseSize = Math.min(app.canvas.width, app.canvas.height)
+  drawEnemy(enemy.level, baseSize * 0.08)
+
+  setStatus(`${enemyLabel(enemy)} blocks your path!`)
+  updateHud()
+  updateProgressBar()
+}
+
+const finishJourney = () => {
+  clearScheduled()
+  game.phase = 'gameover'
+  attackButton.disabled = true
+  enemyGraphic.visible = false
+  currentEnemyLevelForScene = 1
+  setStatus('Your journey north has ended.')
+  updateHud()
+  updateProgressBar()
+  showEndScreen()
+}
+
+const handleEnemyDefeat = () => {
+  if (!game.currentEnemy) return
+
+  game.kills += 1
+  setStatus(`You defeat ${enemyLabel(game.currentEnemy)}!`)
+  game.currentEnemy = null
+  enemyGraphic.visible = false
+  currentEnemyLevelForScene = 1
+  attackButton.disabled = true
+  updateHud()
+  updateProgressBar()
+
+  scheduleTimeout(() => {
+    beginTravel()
+  }, 800)
+}
+
+const handlePlayerAttack = () => {
+  if (game.phase !== 'battle' || !game.currentEnemy) {
+    return
+  }
+
+  const enemy = game.currentEnemy
+  enemy.health = Math.max(0, enemy.health - game.playerDamage)
+  updateHud()
+  setStatus(`You strike ${enemyLabel(enemy)} for ${game.playerDamage} damage!`)
+
+  if (enemy.health <= 0) {
+    handleEnemyDefeat()
+    return
+  }
+
+  game.phase = 'enemy-turn'
+  attackButton.disabled = true
+
+  scheduleTimeout(() => {
+    if (!game.currentEnemy) return
+    const currentEnemy = game.currentEnemy
+    const damage = currentEnemy.attack
+    game.playerHealth = Math.max(0, game.playerHealth - damage)
+    updateHud()
+
+    if (game.playerHealth <= 0) {
+      setStatus(`${enemyLabel(currentEnemy)} strikes the final blow.`)
+      finishJourney()
+      return
+    }
+
+    setStatus(`${enemyLabel(currentEnemy)} hits you for ${damage} damage. Your move!`)
+    game.phase = 'battle'
+    attackButton.disabled = false
+  }, 700)
+}
+
+attackButton.addEventListener('click', handlePlayerAttack)
+
+const restartGame = () => {
+  clearScheduled()
+  game.playerHealth = 100
+  game.kills = 0
+  resetSegments()
+  currentEnemyLevelForScene = 1
+  hideEndScreen()
+  beginTravel()
+}
+
+restartButton.addEventListener('click', restartGame)
+
+beginTravel()
+
+let lastTime = performance.now()
+let bobTimer = 0
+
+const totalLoopDistance = SEGMENT_SPACING * SEGMENT_COUNT
+
+const tick = (time: number) => {
+  const delta = Math.min((time - lastTime) / 1000, 0.12)
+  lastTime = time
+  bobTimer += delta
+
+  const speed = game.phase === 'travel' ? TRAVEL_SPEED : 0
+
+  segments.forEach((segment) => {
+    segment.y += speed * delta
+    if (segment.y - SEGMENT_HEIGHT / 2 > app.canvas.height) {
+      segment.y -= totalLoopDistance
+    }
+  })
+
+  if (game.phase === 'travel') {
+    game.travelProgress = Math.min(game.travelProgress + speed * delta, game.travelTarget)
+    if (game.travelProgress >= game.travelTarget) {
+      beginEncounter()
+    }
+  }
+
+  updateProgressBar()
+
+  playerGraphic.y = playerBaseY + Math.sin(bobTimer * 2.4) * 6
+  enemyGraphic.y = (game.currentEnemy ? enemyBaseY + Math.sin(bobTimer * 1.8) * 4 : enemyBaseY)
+
+  requestAnimationFrame(tick)
+}
+
+requestAnimationFrame((time) => {
+  lastTime = time
+  tick(time)
+})

--- a/src/style.css
+++ b/src/style.css
@@ -26,30 +26,232 @@ body {
 }
 
 canvas {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   display: block;
-  filter: drop-shadow(0 0 20px rgba(56, 189, 248, 0.15));
+  filter: drop-shadow(0 0 18px rgba(56, 189, 248, 0.12));
 }
 
-.scene-label {
+.hud {
   position: absolute;
+  top: 24px;
   left: 50%;
-  bottom: 32px;
   transform: translateX(-50%);
-  text-align: center;
-  font-size: 0.95rem;
+  display: flex;
+  gap: 1.25rem;
+  pointer-events: none;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.hud-card {
+  min-width: 180px;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  padding: 0.9rem 1.2rem;
+  box-shadow: 0 18px 45px rgba(2, 6, 23, 0.55);
+  pointer-events: auto;
+  backdrop-filter: blur(6px);
+}
+
+.hud-title {
+  font-size: 0.85rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+  margin-bottom: 0.6rem;
+}
+
+.hud-metric {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 1.05rem;
+  margin-bottom: 0.35rem;
+}
+
+.hud-metric:last-child {
+  margin-bottom: 0;
+}
+
+.hud-label {
+  font-size: 0.85rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.85);
-  padding: 0.5rem 1.5rem;
-  background: rgba(15, 23, 42, 0.65);
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 999px;
-  backdrop-filter: blur(6px);
-  box-shadow: 0 12px 45px rgba(15, 23, 42, 0.6);
+  color: rgba(148, 163, 184, 0.85);
 }
 
-.scene-label strong {
+.hud-value {
+  font-weight: 600;
+  color: #f1f5f9;
+}
+
+.status {
+  position: absolute;
+  top: 156px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.65rem 1.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(6px);
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  text-align: center;
+  box-shadow: 0 16px 40px rgba(2, 6, 23, 0.5);
+}
+
+.travel-progress {
+  position: absolute;
+  top: 220px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(480px, 78vw);
+  pointer-events: none;
+}
+
+.travel-progress__label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.travel-progress__track {
+  margin-top: 0.55rem;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.6);
+  overflow: hidden;
+  border: 1px solid rgba(30, 41, 59, 0.7);
+}
+
+.travel-progress__fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #38bdf8, #22d3ee);
+  transition: width 0.2s ease;
+}
+
+.controls {
+  position: absolute;
+  bottom: 48px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 1rem;
+  pointer-events: none;
+}
+
+.controls > * {
+  pointer-events: auto;
+}
+
+.attack-button,
+.restart-button {
+  font-family: inherit;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.85rem 2.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.45);
+  color: #0f172a;
+  background: linear-gradient(135deg, #38bdf8, #22d3ee);
+  box-shadow: 0 16px 40px rgba(34, 211, 238, 0.25);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.attack-button:hover:not(:disabled),
+.restart-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 45px rgba(34, 211, 238, 0.35);
+}
+
+.attack-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.end-screen {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(2, 6, 23, 0.82);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.end-screen--visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.end-screen__card {
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 20px;
+  padding: 2.4rem 3rem;
+  text-align: center;
+  box-shadow: 0 32px 60px rgba(2, 6, 23, 0.6);
+  backdrop-filter: blur(10px);
+}
+
+.end-screen__card h2 {
+  margin: 0 0 1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 1.4rem;
   color: #38bdf8;
+}
+
+.end-screen__card p {
+  margin: 0 0 1.8rem;
+  font-size: 1.1rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.end-screen__card strong {
+  color: #38bdf8;
+}
+
+.restart-button {
+  border-color: rgba(56, 189, 248, 0.55);
+}
+
+@media (max-width: 720px) {
+  .hud {
+    top: 18px;
+    gap: 0.85rem;
+  }
+
+  .hud-card {
+    min-width: 150px;
+    padding: 0.75rem 1rem;
+  }
+
+  .status {
+    top: 140px;
+    padding: 0.55rem 1.2rem;
+    font-size: 0.9rem;
+  }
+
+  .travel-progress {
+    top: 200px;
+  }
+
+  .attack-button,
+  .restart-button {
+    font-size: 1rem;
+    padding: 0.75rem 2.2rem;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the demo scene with an endless northbound journey that pauses for turn-based battles, scaling enemies while keeping player health persistent
- add HUD overlays for player/enemy stats, travel progress, battle controls, and an end screen with restart functionality
- refresh styling to support the new heads-up display, controls, progress bar, and game over presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd0181dc08832e99525eea7f09c848